### PR TITLE
add a dockerfile that can build welled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ bin/
 html/
 latex/
 .*swp
-dist/
+dist/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:16.04
+
+COPY . /app
+WORKDIR /app/src
+
+RUN apt-get update                                                                  && \
+    apt-get install -y libcurl4-openssl-dev                                         && \
+    apt-get install -y libnl-3-dev libnl-genl-3-dev libnl-route-3-dev pkg-config    && \
+    apt-get install -y libpng-dev libglib2.0-dev
+
+RUN make x86_64-Linux
+WORKDIR /app/dist/x86_64-Linux


### PR DESCRIPTION
- Adds `dockerfile` that can build apps via the `makefile` using `ubuntu:16.04`
- Adds a temporary file to the `dist` folder to keep it persistent for building, and ignoring that file in the gitignore